### PR TITLE
fbv: fix licence definition

### DIFF
--- a/recipes-graphics/fbv/fbv_1.0b.bb
+++ b/recipes-graphics/fbv/fbv_1.0b.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Frame Buffer Viewer"
-LICENSE = "GPL"
+LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=130f9d9dddfebd2c6ff59165f066e41c"
 DEPENDS = "libpng jpeg"
 PR = "r2"


### PR DESCRIPTION
With krogoth we have the following warning:

WARNING: fbv-1.0b-r2 do_populate_lic: fbv: No generic license file
exists for: GPL in any provider

By looking into COPYING we've found that fbv is under GPLv2